### PR TITLE
from comfy import path

### DIFF
--- a/dreamtalk/configs/default.py
+++ b/dreamtalk/configs/default.py
@@ -1,4 +1,5 @@
 import os
+import folder_paths
 from yacs.config import CfgNode as CN
 
 def find_comfy_dir(current_path):
@@ -11,8 +12,7 @@ def find_comfy_dir(current_path):
             raise Exception("ComfyUI directory not found")
         return find_comfy_dir(parent_path)
 
-script_path = os.path.abspath(__file__)
-comfy_dir = find_comfy_dir(script_path)
+comfy_dir = folder_paths.base_path
 model = os.path.join(comfy_dir, "models", "dreamtalk", "checkpoints", "denoising_network.pth")
 print(f"Model path: {model}")
 _C = CN()


### PR DESCRIPTION
Traceback (most recent call last):
  File "C:\opt\ai\002_ComfyUI_Test\nodes.py", line 1864, in load_custom_node
    module_spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "C:\opt\ai\002_ComfyUI_Test\custom_nodes\ComfyUI-IF_AI_tools\__init__.py", line 10, in <module>
    from .IFDreamTalkNode import IFDreamTalk
  File "C:\opt\ai\002_ComfyUI_Test\custom_nodes\ComfyUI-IF_AI_tools\IFDreamTalkNode.py", line 20, in <module>
    from .dreamtalk.core.utils import (
  File "C:\opt\ai\002_ComfyUI_Test\custom_nodes\ComfyUI-IF_AI_tools\dreamtalk\core\utils.py", line 13, in <module>
    from configs.default import get_cfg_defaults
  File "C:\opt\ai\002_ComfyUI_Test\custom_nodes\ComfyUI-IF_AI_tools\dreamtalk\configs\default.py", line 15, in <module>
    comfy_dir = find_comfy_dir(script_path)
  File "C:\opt\ai\002_ComfyUI_Test\custom_nodes\ComfyUI-IF_AI_tools\dreamtalk\configs\default.py", line 12, in find_comfy_dir
    return find_comfy_dir(parent_path)
  File "C:\opt\ai\002_ComfyUI_Test\custom_nodes\ComfyUI-IF_AI_tools\dreamtalk\configs\default.py", line 12, in find_comfy_dir
    return find_comfy_dir(parent_path)
  File "C:\opt\ai\002_ComfyUI_Test\custom_nodes\ComfyUI-IF_AI_tools\dreamtalk\configs\default.py", line 12, in find_comfy_dir
    return find_comfy_dir(parent_path)
  [Previous line repeated 5 more times]
  File "C:\opt\ai\002_ComfyUI_Test\custom_nodes\ComfyUI-IF_AI_tools\dreamtalk\configs\default.py", line 11, in find_comfy_dir
    raise Exception("ComfyUI directory not found")
Exception: ComfyUI directory not found